### PR TITLE
Make VSCode setup optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@ Clone the canary branch from the repository:
 git clone --branch canary --single-branch https://github.com/pAI-OS/paios.git
 ```
 
-Setup and run the server:
+Setup and run the server (provide the `--vscode` flag to `setup_environment.py`
+if you use VSCode):
 
 _POSIX (Linux/macOS/etc.)_
 
 ```sh
-python3 paios/scripts/setup_environment.py (only on first run)
+python3 paios/scripts/setup_environment.py # only on first run
 source paios/.venv/bin/activate
 python3 -m paios
 ```
@@ -34,7 +35,7 @@ python3 -m paios
 _Windows_
 
 ```sh
-python .\paios\scripts\setup_environment.py (only on first run)
+python .\paios\scripts\setup_environment.py # only on first run
 .\paios\.venv\Scripts\Activate.ps1
 python -m paios
 ```

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -3,7 +3,10 @@ import subprocess
 import sys
 import os
 import shutil
+import argparse
 from pathlib import Path
+from collections.abc import Sequence
+from typing import Optional
 
 # Ensure the parent directory is in sys.path so relative imports work.
 base_dir = Path(__file__).parent.parent
@@ -17,6 +20,8 @@ if os.name == 'nt':  # Windows
     venv_python = venv_dir / 'Scripts' / 'python'
 else:  # POSIX (Linux, macOS, etc.)
     venv_python = venv_dir / 'bin' / 'python'
+
+SUCCESS = 0
 
 def setup_backend():
     print("Setting up the backend environment...")
@@ -50,12 +55,27 @@ def setup_vscode():
             shutil.copy(sample_file, target_file)
             print(f"Copied {sample_file} to {target_file}")
 
-def main():
+def main(argv: Optional[Sequence[str]] = None):
+    parser = argparse.ArgumentParser(
+        description="Setup you paios environment by installing the requisite dependencies."
+    )
+    parser.add_argument(
+        "--vscode", 
+        required=False, 
+        action="store_true",
+        help="Setup vscode configuration."
+    )
+
+    args = parser.parse_args(argv)
+
     setup_backend()
     build_frontend()
-    setup_vscode()
+
+    if args.vscode:
+        setup_vscode()
 
     print("Setup complete.")
+    return SUCCESS
 
 if __name__ == "__main__":
-    main()
+    SystemExit(main())


### PR DESCRIPTION
Some devs do not use VSCode and may like to have the option to opt out of adding configuration files related to the editor.

The README is updated to indicate that you may provide a flag if you use VSCode.

Moreover, the shell command is fixed in the README as round brackets cause an unwanted syntax error.