### PR TITLE
Paios virtual env prompt

### DIFF
--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -21,7 +21,7 @@ else:  # POSIX (Linux, macOS, etc.)
 def setup_backend():
     print("Setting up the backend environment...")
     # Use the system Python to create the virtual environment
-    subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
+    subprocess.run([sys.executable, "-m", "venv", str(venv_dir), "--prompt", "paios"], check=True)
     # Use the Python executable from the virtual environment to install dependencies
     subprocess.run([str(venv_python), "-m", "pip", "install", "-r", str(backend_dir / "requirements.txt")], check=True)
 


### PR DESCRIPTION
Devs may have multiple virtual environments on their machine. The prompt option is a nice way to differentiate them.

![image](https://github.com/pAI-OS/paios/assets/83985775/124bdb57-e7fa-48d4-b66c-16bd3ed8d3d0)
